### PR TITLE
use grid from image if input grid not set

### DIFF
--- a/src/repurpose/img2ts.py
+++ b/src/repurpose/img2ts.py
@@ -320,6 +320,12 @@ class Img2Ts:
 
         try:
             image = self.imgin.read(date, **self.input_kwargs)
+
+            # if input grid is not set, use grid from image
+            # this makes sense if data/image is on a swath orbit grid
+            # and changing from image to image
+            if input_grid is None:
+                input_grid = image.grid
         except IOError as e:
             msg = "I/O error({0}): {1}".format(e.errno,
                                                e.strerror)

--- a/src/repurpose/resample.py
+++ b/src/repurpose/resample.py
@@ -220,6 +220,9 @@ def resample_to_grid(input_data, src_lon, src_lat, target_lon, target_lat,
                                                               min_neighbours=min_neighbours,
                                                               search_rad=search_rad,
                                                               neighbours=neighbours)
+
+    not_masked = ~mask
+
     for param in input_data:
         data = resampled_data[param]
         orig_data = input_data[param]
@@ -236,8 +239,8 @@ def resample_to_grid(input_data, src_lon, src_lat, target_lon, target_lat,
         else:
             output_array = np.zeros(target_lat.shape, dtype=orig_data.dtype)
             output_array = np.ma.array(output_array, mask=mask)
-        output_array[~mask] = data
 
+        output_array[not_masked] = data
         output_data[param] = output_array.reshape(output_shape)
 
     return output_data


### PR DESCRIPTION
Important for data located on changing swath orbit grid

The second change resample.py, i.e. `not_masked = ~mask` was needed because for some reason at the 3rd or 4th loop mask has been changed for an unknown reason. Evaluating the mask before the loop solved this strange problem